### PR TITLE
upgrade to go 1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2
 jobs:
   build:
-    working_directory: /go/src/github.com/Clever/log-replay
+    working_directory: ~/go/src/github.com/Clever/log-replay
     docker:
-    - image: circleci/golang:1.13-stretch
+    - image: cimg/go:1.21
     environment:
       GOPRIVATE: github.com/Clever/*
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ COMPRESSED_BUILDS := $(BUILDS:%=%.tar.gz)
 RELEASE_ARTIFACTS := $(COMPRESSED_BUILDS:build/%=release/%)
 .PHONY: test $(PKGS) clean release
 
-$(eval $(call golang-version-check,1.13))
+$(eval $(call golang-version-check,1.21))
 
 all: test build
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/Clever/log-replay
 
-go 1.16
+go 1.21
 
 require github.com/stretchr/testify v1.6.1
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRANG-5578

This PR updates go to version 1.21. Welcome to the future. 


# Testing
No actual testing done for this specific repo other than `make test` 
LOTS of testing done for services in general, wag services specifically etc and 99% of services are on 1.21 already.
#
